### PR TITLE
Add an ACL check in page_findnearest, fix #1369

### DIFF
--- a/_test/tests/inc/pageutils_findnearest.test.php
+++ b/_test/tests/inc/pageutils_findnearest.test.php
@@ -1,6 +1,33 @@
 <?php
 
 class pageutils_findnearest_test extends DokuWikiTest {
+
+    var $oldAuthAcl;
+
+    function setUp() {
+        parent::setUp();
+        global $AUTH_ACL;
+        global $auth;
+        global $conf;
+        $conf['superuser'] = 'john';
+        $conf['useacl']    = 1;
+
+        $this->oldAuthAcl = $AUTH_ACL;
+        $auth = new DokuWiki_Auth_Plugin();
+
+        $AUTH_ACL = array(
+            '*           @ALL           1',
+            'internal:*    @ALL           0',
+            'internal:*    max            1',
+            '*           @user          8',
+        );
+    }
+
+    function tearDown() {
+        global $AUTH_ACL;
+        $AUTH_ACL = $this->oldAuthAcl;
+    }
+
     function testNoSidebar() {
         global $ID;
 
@@ -37,4 +64,26 @@ class pageutils_findnearest_test extends DokuWikiTest {
         $this->assertEquals('sidebar', $sidebar);
     }
 
+    function testACLWithSidebar() {
+        global $ID;
+        global $INPUT;
+
+        $INPUT->server->set('REMOTE_USER', 'foo');
+
+        saveWikiText('sidebar', 'top sidebar', '');
+        saveWikiText('internal:sidebar', 'internal sidebar', '');
+
+        $ID = 'internal:foo:bar';
+
+        $sidebar = page_findnearest('sidebar');
+        $this->assertEquals('sidebar', $sidebar);
+
+        $sidebar = page_findnearest('sidebar', true);
+        $this->assertEquals('internal:sidebar', $sidebar);
+
+        $INPUT->server->set('REMOTE_USER', 'max');
+
+        $sidebar = page_findnearest('sidebar');
+        $this->assertEquals('internal:sidebar', $sidebar);
+    }
 }

--- a/inc/pageutils.php
+++ b/inc/pageutils.php
@@ -738,24 +738,26 @@ function utf8_decodeFN($file){
 
 /**
  * Find a page in the current namespace (determined from $ID) or any
- * higher namespace
+ * higher namespace that can be accessed by the current user,
+ * this condition can be overriden by an optional parameter.
  *
  * Used for sidebars, but can be used other stuff as well
  *
  * @todo   add event hook
  *
  * @param  string $page the pagename you're looking for
- * @return string|false the full page id of the found page, false if any
+ * @param bool $ignoreacl If pages that can't be accessed by the current user shall be returend
+ * @return false|string the full page id of the found page, false if any
  */
-function page_findnearest($page){
+function page_findnearest($page, $ignoreacl = false){
     if (!$page) return false;
     global $ID;
 
     $ns = $ID;
     do {
         $ns = getNS($ns);
-        $pageid = ltrim("$ns:$page",':');
-        if(page_exists($pageid)){
+        $pageid = cleanID("$ns:$page");
+        if(page_exists($pageid) && ($ignoreacl || auth_quickaclcheck($pageid) > 0)){
             return $pageid;
         }
     } while($ns);


### PR DESCRIPTION
This means that templates that use this function will no longer display
pages like sidebars that can't be accessed by the current user.dokuwiki